### PR TITLE
Fix Google Auth Key Format

### DIFF
--- a/src/utils/googleAuth.js
+++ b/src/utils/googleAuth.js
@@ -1,0 +1,18 @@
+const formatGooglePrivateKey = (key) => {
+  if (!key) throw new Error('Google private key is required');
+  
+  // Replace escaped newlines with actual newlines
+  let formattedKey = key.replace(/\\n/g, '\n');
+  
+  // Ensure key has proper PEM format headers if they're missing
+  if (!formattedKey.includes('-----BEGIN PRIVATE KEY-----')) {
+    formattedKey = `-----BEGIN PRIVATE KEY-----\n${formattedKey}`;
+  }
+  if (!formattedKey.includes('-----END PRIVATE KEY-----')) {
+    formattedKey = `${formattedKey}\n-----END PRIVATE KEY-----`;
+  }
+  
+  return formattedKey;
+};
+
+module.exports = { formatGooglePrivateKey };


### PR DESCRIPTION
This PR fixes the DECODER routines::unsupported error by properly formatting the Google private key.

Changes:
- Added utility function to handle Google private key formatting
- Ensures proper PEM format with headers
- Handles escaped newlines in the key

The error was occurring because the private key wasn't in the correct format expected by the Google Auth library. This fix ensures the key is properly formatted before use.